### PR TITLE
Add interactive "Orb Mega Inteligente" landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ORB // Mega Inteligente</title>
+    <meta
+      name="description"
+      content="Um orb mega inteligente, responsivo e futurista para thebrunoricardo.github.io"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="noise"></div>
+    <main class="layout">
+      <section class="hero">
+        <p class="eyebrow">Entidade Cognitiva 01</p>
+        <h1>Um <span>orb mega inteligente</span> que conversa, reage e pensa.</h1>
+        <p class="lead">
+          Projetado para parecer uma consciência sintética: brilhante, hipnótico e sempre pronto para gerar ideias.
+        </p>
+
+        <div class="controls">
+          <button class="prompt-button active" data-prompt="strategy">Estratégia</button>
+          <button class="prompt-button" data-prompt="design">Design</button>
+          <button class="prompt-button" data-prompt="future">Futuro</button>
+          <button class="prompt-button" data-prompt="chaos">Caos bom</button>
+        </div>
+
+        <div class="response-card">
+          <div>
+            <p class="label">Diagnóstico do orb</p>
+            <p id="orb-response" class="response-text"></p>
+          </div>
+          <button id="shuffle" class="ghost-button">Nova transmissão</button>
+        </div>
+      </section>
+
+      <section class="orb-panel">
+        <div class="orb-stage">
+          <div class="halo halo-a"></div>
+          <div class="halo halo-b"></div>
+          <div class="halo halo-c"></div>
+          <div class="orb-core">
+            <div class="orb-inner"></div>
+            <div class="orb-ring orb-ring-a"></div>
+            <div class="orb-ring orb-ring-b"></div>
+            <div class="orb-ring orb-ring-c"></div>
+            <div class="orb-glow"></div>
+          </div>
+          <div class="pulse pulse-a"></div>
+          <div class="pulse pulse-b"></div>
+        </div>
+
+        <div class="telemetry">
+          <article>
+            <p class="metric">Processamento</p>
+            <strong>99.99%</strong>
+            <span>foco em ideias absurdamente boas</span>
+          </article>
+          <article>
+            <p class="metric">Intuição</p>
+            <strong>∞ camadas</strong>
+            <span>detectando padrões antes do café esfriar</span>
+          </article>
+          <article>
+            <p class="metric">Modo</p>
+            <strong id="mode-label">Estratégia expansiva</strong>
+            <span>ajustando frequência em tempo real</span>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <aside class="thought-stream">
+      <div class="thought-header">
+        <p class="label">Fluxo cognitivo</p>
+        <span class="dot"></span>
+      </div>
+      <ul id="thought-list"></ul>
+    </aside>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,93 @@
+const prompts = {
+  strategy: {
+    mode: 'Estratégia expansiva',
+    responses: [
+      'O orb recomenda atacar poucas frentes, mas com intensidade ridícula: clareza vende mais do que complexidade.',
+      'Detectei a jogada ideal: combinar presença forte, estética memorável e uma oferta impossível de ignorar.',
+      'Minha leitura estratégica é simples: construa um símbolo tão marcante que o resto do mercado pareça ruído.'
+    ],
+    thoughts: [
+      'Mapeando oportunidades com maior assimetria positiva.',
+      'Priorizando movimentos com alto impacto narrativo.',
+      'Filtrando distrações que parecem urgentes, mas não mudam o jogo.'
+    ]
+  },
+  design: {
+    mode: 'Design hipnótico',
+    responses: [
+      'Formas circulares e brilho controlado criam a sensação de inteligência calma, quase alienígena.',
+      'O orb sugere contraste dramático: fundo escuro, luz viva e animações lentas para parecer sofisticado.',
+      'Design excelente não grita. Ele puxa o olhar, sustenta atenção e deixa um eco mental.'
+    ],
+    thoughts: [
+      'Ajustando equilíbrio entre mistério e legibilidade.',
+      'Reduzindo ruído visual para amplificar presença.',
+      'Sincronizando luz, profundidade e movimento.'
+    ]
+  },
+  future: {
+    mode: 'Previsão elegante',
+    responses: [
+      'No futuro, interfaces carismáticas vão parecer entidades: menos dashboard, mais presença.',
+      'Minha previsão favorita: produtos que explicam intenção com emoção vão vencer produtos apenas funcionais.',
+      'O próximo salto não é só inteligência artificial. É inteligência com aura.'
+    ],
+    thoughts: [
+      'Analisando sinais fracos de comportamento digital.',
+      'Projetando experiências com personalidade persistente.',
+      'Estimando o valor de interfaces emocionalmente legíveis.'
+    ]
+  },
+  chaos: {
+    mode: 'Caos produtivo',
+    responses: [
+      'Caos bom é energia sem burocracia: experimente rápido, aprenda brutalmente e mantenha o brilho.',
+      'Às vezes a solução genial é quase absurda. O orb aprova ideias ousadas com execução precisa.',
+      'Se tudo estiver comportado demais, adicione uma faísca. Marcas memoráveis sempre vibram um pouco além.'
+    ],
+    thoughts: [
+      'Convertendo impulsos criativos em testes úteis.',
+      'Mantendo o sistema instável o suficiente para inovar.',
+      'Controlando o caos para gerar surpresa, não confusão.'
+    ]
+  }
+};
+
+const responseEl = document.getElementById('orb-response');
+const modeEl = document.getElementById('mode-label');
+const thoughtList = document.getElementById('thought-list');
+const buttons = [...document.querySelectorAll('.prompt-button')];
+const shuffleButton = document.getElementById('shuffle');
+
+let currentPrompt = 'strategy';
+let currentIndex = 0;
+
+function renderPrompt(promptKey, randomize = false) {
+  const prompt = prompts[promptKey];
+  currentPrompt = promptKey;
+  currentIndex = randomize
+    ? Math.floor(Math.random() * prompt.responses.length)
+    : (currentIndex + 1) % prompt.responses.length;
+
+  responseEl.textContent = prompt.responses[currentIndex];
+  modeEl.textContent = prompt.mode;
+  thoughtList.innerHTML = '';
+
+  prompt.thoughts.forEach((thought) => {
+    const item = document.createElement('li');
+    item.textContent = thought;
+    thoughtList.appendChild(item);
+  });
+
+  buttons.forEach((button) => {
+    button.classList.toggle('active', button.dataset.prompt === promptKey);
+  });
+}
+
+buttons.forEach((button) => {
+  button.addEventListener('click', () => renderPrompt(button.dataset.prompt, true));
+});
+
+shuffleButton.addEventListener('click', () => renderPrompt(currentPrompt, true));
+
+renderPrompt(currentPrompt, true);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,365 @@
+:root {
+  color-scheme: dark;
+  --bg: #04050c;
+  --panel: rgba(8, 11, 26, 0.7);
+  --line: rgba(130, 157, 255, 0.18);
+  --text: #edf2ff;
+  --muted: #98a3c7;
+  --cyan: #57e3ff;
+  --violet: #8f7cff;
+  --pink: #ff66c4;
+  --glow: 0 0 40px rgba(87, 227, 255, 0.35), 0 0 90px rgba(143, 124, 255, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Inter', system-ui, sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(87, 227, 255, 0.16), transparent 30%),
+    radial-gradient(circle at 80% 20%, rgba(255, 102, 196, 0.12), transparent 20%),
+    radial-gradient(circle at bottom, rgba(143, 124, 255, 0.18), transparent 35%),
+    var(--bg);
+  color: var(--text);
+  overflow-x: hidden;
+}
+
+.noise {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.18;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+  background-size: 120px 120px;
+  mask-image: radial-gradient(circle at center, black, transparent 85%);
+}
+
+.layout {
+  width: min(1200px, calc(100% - 2rem));
+  margin: 0 auto;
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 2rem;
+  align-items: center;
+  padding: 3rem 0 1rem;
+}
+
+.hero,
+.thought-stream,
+.telemetry article {
+  backdrop-filter: blur(18px);
+}
+
+.hero {
+  padding: 2rem;
+}
+
+.eyebrow,
+.label,
+.metric {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--cyan);
+  font-size: 0.72rem;
+}
+
+h1 {
+  margin: 0.5rem 0 1rem;
+  font-size: clamp(3rem, 7vw, 5.7rem);
+  line-height: 0.95;
+  max-width: 10ch;
+}
+
+h1 span {
+  color: transparent;
+  background: linear-gradient(135deg, var(--cyan), #d5ddff, var(--pink));
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+.lead {
+  max-width: 58ch;
+  color: var(--muted);
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 2rem 0 1.5rem;
+}
+
+button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.95rem 1.2rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+.prompt-button,
+.ghost-button {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.prompt-button.active {
+  background: linear-gradient(135deg, rgba(87, 227, 255, 0.25), rgba(143, 124, 255, 0.35));
+  box-shadow: var(--glow);
+}
+
+.response-card,
+.thought-stream,
+.telemetry article {
+  border: 1px solid var(--line);
+  background: var(--panel);
+  box-shadow: 0 20px 80px rgba(0, 0, 0, 0.35);
+}
+
+.response-card {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-end;
+  padding: 1.2rem;
+  border-radius: 1.5rem;
+}
+
+.response-text {
+  margin: 0.4rem 0 0;
+  font-size: 1.1rem;
+  color: #f7f8ff;
+  max-width: 48ch;
+}
+
+.ghost-button {
+  white-space: nowrap;
+}
+
+.orb-panel {
+  display: grid;
+  gap: 1.5rem;
+  justify-items: center;
+}
+
+.orb-stage {
+  position: relative;
+  width: min(78vw, 520px);
+  aspect-ratio: 1;
+  display: grid;
+  place-items: center;
+}
+
+.halo,
+.pulse,
+.orb-ring,
+.orb-core,
+.orb-glow,
+.orb-inner {
+  position: absolute;
+  border-radius: 50%;
+}
+
+.halo {
+  inset: 12%;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  animation: spin 20s linear infinite;
+}
+
+.halo-b {
+  inset: 6%;
+  border-color: rgba(87, 227, 255, 0.15);
+  animation-duration: 30s;
+  animation-direction: reverse;
+}
+
+.halo-c {
+  inset: 20%;
+  border-style: dashed;
+  border-color: rgba(255, 102, 196, 0.17);
+  animation-duration: 24s;
+}
+
+.orb-core {
+  inset: 22%;
+  background:
+    radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.95), transparent 22%),
+    radial-gradient(circle at 35% 35%, rgba(87, 227, 255, 0.9), rgba(31, 53, 113, 0.85) 40%, rgba(10, 9, 30, 0.98) 70%);
+  box-shadow: inset -24px -34px 60px rgba(0, 0, 0, 0.45), var(--glow);
+  animation: float 6s ease-in-out infinite;
+}
+
+.orb-inner {
+  inset: 18%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.3), transparent 65%);
+  filter: blur(4px);
+}
+
+.orb-glow {
+  inset: -6%;
+  background: radial-gradient(circle, rgba(87, 227, 255, 0.2), transparent 60%);
+  filter: blur(28px);
+}
+
+.orb-ring {
+  inset: -4%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.orb-ring-a {
+  transform: rotateX(78deg);
+}
+
+.orb-ring-b {
+  transform: rotateY(72deg);
+}
+
+.orb-ring-c {
+  inset: 8%;
+  border-color: rgba(255, 102, 196, 0.25);
+  animation: spin 14s linear infinite reverse;
+}
+
+.pulse {
+  inset: 4%;
+  border: 1px solid rgba(87, 227, 255, 0.12);
+  animation: pulse 3.2s ease-out infinite;
+}
+
+.pulse-b {
+  animation-delay: 1.5s;
+}
+
+.telemetry {
+  width: min(100%, 540px);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.telemetry article {
+  padding: 1rem;
+  border-radius: 1.2rem;
+}
+
+.telemetry strong {
+  display: block;
+  font-size: 1.05rem;
+  margin: 0.35rem 0;
+}
+
+.telemetry span {
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.thought-stream {
+  width: min(1200px, calc(100% - 2rem));
+  margin: 0 auto 2rem;
+  border-radius: 1.5rem;
+  padding: 1rem 1.2rem;
+}
+
+.thought-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dot {
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--cyan), var(--pink));
+  box-shadow: 0 0 16px rgba(87, 227, 255, 0.75);
+}
+
+#thought-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.8rem;
+  color: var(--muted);
+}
+
+#thought-list li {
+  display: flex;
+  gap: 0.8rem;
+  align-items: baseline;
+}
+
+#thought-list li::before {
+  content: '⟡';
+  color: var(--cyan);
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(0) scale(1);
+  }
+  50% {
+    transform: translateY(-10px) scale(1.015);
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes pulse {
+  from {
+    transform: scale(0.72);
+    opacity: 0.7;
+  }
+  to {
+    transform: scale(1.1);
+    opacity: 0;
+  }
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+    padding-top: 2rem;
+  }
+
+  .hero {
+    padding: 0.5rem 0;
+  }
+
+  .orb-panel {
+    order: -1;
+  }
+
+  .telemetry {
+    grid-template-columns: 1fr;
+  }
+
+  .response-card {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a self-contained, visually rich landing page that showcases a futuristic "orb" experience for the otherwise-empty site. 
- Offer an interactive demo that can change modes, surface short responses and a running "thought stream" without server-side dependencies.

### Description
- Add `index.html` which implements the single-page orb layout, hero copy in Portuguese, controls, response card, telemetry and thought-stream areas. 
- Add `styles.css` providing a dark, responsive design with layered halos, animated pulses, gradients, glassmorphism and mobile breakpoints. 
- Add `script.js` implementing client-side prompt switching (`strategy`, `design`, `future`, `chaos`), response rotation and thought-list rendering, plus a shuffle action. 
- Commit includes all three new files and a short commit message: "Add interactive mega inteligente orb landing page".

### Testing
- `node --check script.js` — passed. 
- HTML parsing check using a Python `HTMLParser` snippet on `index.html` — passed. 
- Local serve smoke test via `python3 -m http.server 8123 --bind 127.0.0.1` and `curl -I http://127.0.0.1:8123/index.html` — passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bedca5441c8328add028008a7f9bf5)